### PR TITLE
feat: add the service instance endpoint

### DIFF
--- a/lib/openshift-rest-client.js
+++ b/lib/openshift-rest-client.js
@@ -25,6 +25,8 @@ const path = require('path');
 const { Client, config, alias } = require('kubernetes-client');
 const { getTokenFromBasicAuth } = require('./basic-auth-request');
 
+const serviceCatalogCRD = require('./specs/service-catalog-crd.json');
+
 // A list of shorthand aliases
 const resourceAliases = {
   'apps.openshift.io': ['app'],
@@ -85,6 +87,9 @@ async function openshiftClient (settings = {}) {
 
   // TODO: need to be able to pass in the config object here
   const client = new Client({ config: kubeconfig || config.fromKubeconfig(), spec, getNames: getNames });
+
+  // CRD with the service instance stuff, but only to this client, not the cluster
+  client.addCustomResourceDefinition(serviceCatalogCRD);
   return client;
 }
 

--- a/lib/specs/service-catalog-crd.json
+++ b/lib/specs/service-catalog-crd.json
@@ -1,0 +1,17 @@
+{
+  "kind": "CustomResourceDefinition",
+  "spec": {
+    "scope": "Namespaced",
+    "version": "v1beta1",
+    "group": "servicecatalog.k8s.io",
+    "names": {
+      "shortNames": [
+        "si"
+      ],
+      "kind": "ServiceInstance",
+      "plural": "serviceinstances",
+      "singular": "serviceinstance"
+    }
+  },
+  "apiVersion": "servicecatalog.k8s.io/v1beta1"
+}


### PR DESCRIPTION
fixes #121


@tremes want to give this a try

the below example should do something

```
'use strict';

const openshiftRestClient = require('openshift-rest-client').OpenshiftClient;

(async function () {
  const client = await openshiftRestClient();

  const sc = await client.apis['servicecatalog.k8s.io'].v1beta1.serviceinstance.get();

  console.log(sc);
})();
```