### PR TITLE
fix: remove warnings about deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ For example, if you want to provide a different path to your configuration, you 
     const config = require('openshift-rest-client').config;
 
     const path '~/some/path/config';
-    const customConfig = config.fromKubeconfig(path);
+    const customConfig = config.loadFromFile(path);
 
     openshiftRestClient({config: customConfig}).then((client) => {
       // Use the client object to find a list of projects, for example

--- a/index.js
+++ b/index.js
@@ -20,5 +20,5 @@
 
 module.exports = exports = {
   OpenshiftClient: require('./lib/openshift-rest-client.js'),
-  config: require('kubernetes-client/backends/request').config
+  config: new (require('kubernetes-client').KubeConfig)()
 };

--- a/index.js
+++ b/index.js
@@ -20,5 +20,5 @@
 
 module.exports = exports = {
   OpenshiftClient: require('./lib/openshift-rest-client.js'),
-  config: require('kubernetes-client').config
+  config: require('kubernetes-client/backends/request').config
 };

--- a/lib/openshift-rest-client.js
+++ b/lib/openshift-rest-client.js
@@ -22,7 +22,7 @@ const zlib = require('zlib');
 const fs = require('fs');
 const path = require('path');
 
-const { Client, config, alias } = require('kubernetes-client');
+const { Client, alias } = require('kubernetes-client');
 const { getTokenFromBasicAuth } = require('./basic-auth-request');
 
 const serviceCatalogCRD = require('./specs/service-catalog-crd.json');
@@ -92,7 +92,7 @@ async function openshiftClient (settings = {}) {
     }
   }
 
-  const client = new Client({ config: kubeconfig || config.fromKubeconfig(), spec, getNames: getNames });
+  const client = new Client({ config: kubeconfig, spec, getNames: getNames });
 
   // CRD with the service instance stuff, but only to this client, not the cluster
   client.addCustomResourceDefinition(serviceCatalogCRD);

--- a/lib/openshift-rest-client.js
+++ b/lib/openshift-rest-client.js
@@ -22,8 +22,9 @@ const zlib = require('zlib');
 const fs = require('fs');
 const path = require('path');
 
-const { Client, alias } = require('kubernetes-client');
+const { Client, alias, KubeConfig } = require('kubernetes-client');
 const { getTokenFromBasicAuth } = require('./basic-auth-request');
+const Request = require('kubernetes-client/backends/request');
 
 const serviceCatalogCRD = require('./specs/service-catalog-crd.json');
 
@@ -69,30 +70,67 @@ const spec = JSON.parse(zlib.gunzipSync(fs.readFileSync(path.join(__dirname, 'sp
  * @returns {Promise} Returns the Rest Client
  */
 async function openshiftClient (settings = {}) {
-  let kubeconfig = settings.config;
+  let config = settings.config;
+  const clientConfig = { backend: null, spec, getNames };
 
-  if (kubeconfig) {
+  if (config) {
     // A config is being passed in.  Check if it is an object
-    if (typeof kubeconfig === 'object' && kubeconfig.auth) {
+    if (typeof config === 'object' && config.auth) {
       // Check for the auth username password
-      if ('user' in kubeconfig.auth || 'username' in kubeconfig.auth) {
+      if ('user' in config.auth || 'username' in config.auth) {
         // They are trying the basic auth.
         // Get the access token using the username and password
         // Check to see if we are passing in a username/password
-        const accessToken = await getTokenFromBasicAuth({ insecureSkipTlsVerify: kubeconfig.insecureSkipTlsVerify, url: kubeconfig.url, user: kubeconfig.auth.username || kubeconfig.auth.user, password: kubeconfig.auth.password || kubeconfig.auth.pass, authUrl: kubeconfig.authUrl });
+        const { insecureSkipTlsVerify, url, authUrl } = config;
+        const user = config.auth.username || config.auth.user;
+        const password = config.auth.password || config.auth.pass;
 
-        kubeconfig = {
-          url: kubeconfig.url,
-          auth: {
-            bearer: accessToken
-          },
-          insecureSkipTlsVerify: 'insecureSkipTlsVerify' in kubeconfig ? Boolean(kubeconfig.insecureSkipTlsVerify) : false
+        const accessToken = await getTokenFromBasicAuth({ insecureSkipTlsVerify, url, user, password, authUrl });
+        const clusterUrl = authUrl || url;
+        // Create clusterName from clusterUrl by removing 'https://'
+        const clusterName = clusterUrl.replace(/(^\w+:|^)\/\//, '');
+        config = {
+          apiVersion: 'v1',
+          clusters: [
+            {
+              cluster: {
+                server: clusterUrl,
+                'insecure-skip-tls-verify': insecureSkipTlsVerify
+              },
+              name: clusterName
+            }
+          ],
+          contexts: [
+            {
+              context: {
+                cluster: clusterName,
+                user: `${user}/${clusterName}`
+              },
+              name: `default/${clusterName}/${user}`
+            }
+          ],
+          'current-context': `default/${clusterName}/${user}`,
+          kind: 'Config',
+          preferences: {},
+          users: [
+            {
+              name: `${user}/${clusterName}`,
+              user: {
+                token: accessToken
+              }
+            }
+          ]
         };
+
+        const kubeconfig = new KubeConfig();
+        kubeconfig.loadFromString(JSON.stringify(config));
+        clientConfig.backend = new Request({ kubeconfig });
       }
+    } else if (config.clusters) {
+      clientConfig.backend = new Request({ kubeconfig: config });
     }
   }
-
-  const client = new Client({ config: kubeconfig, spec, getNames: getNames });
+  const client = new Client(clientConfig);
 
   // CRD with the service instance stuff, but only to this client, not the cluster
   client.addCustomResourceDefinition(serviceCatalogCRD);

--- a/test/openshift-client-test.js
+++ b/test/openshift-client-test.js
@@ -73,7 +73,7 @@ test('openshift client tests', (t) => {
 test('test basic auth - username/password', async (t) => {
   const settings = {
     config: {
-      url: 'http://',
+      url: 'http://test-url',
       auth: {
         username: 'luke',
         password: 'password'
@@ -109,7 +109,7 @@ test('test basic auth - username/password', async (t) => {
 test('test basic auth - user/pass', async (t) => {
   const settings = {
     config: {
-      url: 'http://',
+      url: 'http://test-url',
       auth: {
         user: 'luke',
         pass: 'password'
@@ -147,7 +147,7 @@ test('test basic auth - user/pass', async (t) => {
 test('test different config', async (t) => {
   const settings = {
     config: {
-      url: 'http://',
+      url: 'http://test-url',
       insecureSkipTlsVerify: true
     }
   };
@@ -178,7 +178,7 @@ test('test different config', async (t) => {
 test('test different config with auth and no user/username', async (t) => {
   const settings = {
     config: {
-      url: 'http://',
+      url: 'http://test-url',
       auth: {},
       insecureSkipTlsVerify: true
     }


### PR DESCRIPTION
### Motivation
To remove warning messages about deprecated constructs


E.g. this
```
require('openshift-rest-client').OpenshiftClient()
```
results in
```
kubernetes-client deprecated require('kubernetes-client').config, use require('kubernetes-client/backends/request').config. node_modules/openshift-rest-client/lib/openshift-rest-client.js:25:35
kubernetes-client deprecated require('kubernetes-client').config, use require('kubernetes-client/backends/request').config. node_modules/openshift-rest-client/index.js:23:39
kubernetes-client deprecated fromKubeconfig see https://github.com/godaddy/kubernetes-client/blob/master/merging-with-kubernetes.md#request-kubeconfig- node_modules/openshift-rest-client/lib/openshift-rest-client.js:95:60
kubernetes-client deprecated Client({ config }), see https://github.com/godaddy/kubernetes-client/blob/master/merging-with-kubernetes.md node_modules/openshift-rest-client/lib/openshift-rest-client.js:95:18
kubernetes-client deprecated Request() without a .kubeconfig option, see https://github.com/godaddy/kubernetes-client/blob/master/merging-with-kubernetes.md node_modules/kubernetes-client/lib/swagger-client.js:200:19
```

This PR should fix it.


`npm test` passed
```
  total:     48
  passing:   48
  duration:  1.1s
```