### PR TITLE
Use token when available

### DIFF
--- a/lib/openshift-rest-client.js
+++ b/lib/openshift-rest-client.js
@@ -85,7 +85,7 @@ async function openshiftClient (settings = {}) {
         const user = config.auth.username || config.auth.user;
         const password = config.auth.password || config.auth.pass;
 
-        const accessToken = await getTokenFromBasicAuth({ insecureSkipTlsVerify, url, user, password, authUrl });
+        const accessToken = config.auth.token ? config.auth.token : await getTokenFromBasicAuth({ insecureSkipTlsVerify, url, user, password, authUrl });
         const clusterUrl = authUrl || url;
         // Create clusterName from clusterUrl by removing 'https://'
         const clusterName = clusterUrl.replace(/(^\w+:|^)\/\//, '');


### PR DESCRIPTION
Hi!

I'm currently using openshift-rest-client, and i needed a way to log in with username & token, so i adapted the code to accept a token when present.

What do you think about this change?