### PR TITLE
feat: load config from a file location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,10 @@ The openshift-rest-client exposes the config module from the kubernetes client f
 For example, if you want to provide a different path to your configuration, you can do something like this:
 
     const openshiftRestClient = require('openshift-rest-client').OpenshiftClient;
-    const config = require('openshift-rest-client').config;
 
-    const path '~/some/path/config';
-    const customConfig = config.loadFromFile(path);
+    const config = '~/some/path/config';
 
-    openshiftRestClient({config: customConfig}).then((client) => {
+    openshiftRestClient({ config }).then((client) => {
       // Use the client object to find a list of projects, for example
       client.apis['project.openshift.io'].v1.project.get().then((response) => {
         console.log(response.body);

--- a/lib/openshift-rest-client.js
+++ b/lib/openshift-rest-client.js
@@ -61,7 +61,7 @@ const spec = JSON.parse(zlib.gunzipSync(fs.readFileSync(path.join(__dirname, 'sp
  * Builds the rest client based on provided or default kubernetes configuration.
  *
  * @param {object} [settings] - settings object for the openshiftClient function
- * @param {object} [settings.config] - custom config object
+ * @param {object|string} [settings.config] - custom config object.  String value will assume a config file location
  * @param {string} [settings.config.url] - Openshift cluster url
  * @param {string} [settings.config.authUrl] - Openshift Basic auth url
  * @param {object} [settings.config.auth] -
@@ -78,8 +78,13 @@ async function openshiftClient (settings = {}) {
   let fullyUserDefined = false;
 
   if (config) {
-    // A config is being passed in.  Check if it is an object
-    if (typeof config === 'object' && config.auth) {
+    // A config is being passed in.
+    if (typeof config === 'string') {
+      // This is the config location
+      // load from file
+      kubeconfig.loadFromFile(config);
+      clientConfig.backend = new Request({ kubeconfig });
+    } else if (typeof config === 'object' && config.auth) {
       // Check for the auth username password
       if ('user' in config.auth || 'username' in config.auth) {
         // They are trying the basic auth.

--- a/test/openshift-client-test.js
+++ b/test/openshift-client-test.js
@@ -222,3 +222,17 @@ test('test different config - user defined', async (t) => {
   t.pass();
   t.end();
 });
+
+test('test different config - different location as a string', async (t) => {
+  const openshiftRestClient = require('../');
+
+  const configLocation = `${__dirname}/test-config`;
+  const settings = {
+    config: configLocation
+  };
+
+  const client = await openshiftRestClient.OpenshiftClient(settings);
+  const { kubeconfig } = client;
+  t.equal(kubeconfig.currentContext, 'for-node-client-testing/192-168-99-100:8443/developer', 'current context is correctly loaded');
+  t.end();
+});


### PR DESCRIPTION
This adds the ability to pass in a string value for `settings.config`, which points to the location of a kubernetes/optionshift config

fixes #189