### PR TITLE
Load from cluster spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ By default, the openshift-rest-client, will load a swagger spec file that is inc
 
 To fix this, you can tell the openshift-rest-client to load the spec file from your remote cluster using the `loadSpecFromCluster` option.  Setting this to true, will try to load the spec file from your clusters `/openapi/v2` endpoint.  If that doesn't exist, it will also try, `/swagger.json`
 
+If the remote spec cannot be loaded,  a warning will be output to the console and the default spec will be loaded.
+
 In a future version of this client,  this might become the default.
 
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ const openshiftRestClient = require('openshift-rest-client').OpenshiftClient;
 
 To see more examples of how to customize your config, check out the [kubernetes-client Initializing section](https://www.npmjs.com/package/kubernetes-client#initializing)
 
+#### Load API from a Remote Cluster
+
+By default, the openshift-rest-client, will load a swagger spec file that is included with the module.  This has all the basic API's that come with Openshift and Kubernetes.  If you are using operators to extend your cluster, the openshift-rest-client, by default, won't know about them.
+
+To fix this, you can tell the openshift-rest-client to load the spec file from your remote cluster using the `loadSpecFromCluster` option.  Setting this to true, will try to load the spec file from your clusters `/openapi/v2` endpoint.  If that doesn't exist, it will also try, `/swagger.json`
+
+In a future version of this client,  this might become the default.
+
 
 
 #### Changes in 2.0

--- a/lib/openshift-rest-client.js
+++ b/lib/openshift-rest-client.js
@@ -76,7 +76,6 @@ async function openshiftClient (settings = {}) {
   const clientConfig = { backend: null, /* spec, */ getNames };
 
   if (!settings.loadSpec) {
-    console.log('using harcoded');
     clientConfig.spec = spec;
   }
 
@@ -152,7 +151,6 @@ async function openshiftClient (settings = {}) {
 
   const client = new Client(clientConfig);
   if (settings.loadSpec) {
-    console.log('using cluster one');
     await client.loadSpec();
   }
 

--- a/lib/openshift-rest-client.js
+++ b/lib/openshift-rest-client.js
@@ -150,9 +150,17 @@ async function openshiftClient (settings = {}) {
     clientConfig.backend = new Request({ kubeconfig });
   }
 
-  const client = new Client(clientConfig);
+  let client = new Client(clientConfig);
   if (settings.loadSpecFromCluster) {
-    await client.loadSpec();
+    try {
+      await client.loadSpec();
+    } catch (err) {
+      // Warn the user there was an error and loading the other spec
+      console.warn('Warning: Remote client spec unable to load', err.message);
+      console.warn('Warning: Loading default spec instead');
+      clientConfig.spec = spec;
+      client = new Client(clientConfig);
+    }
   }
 
   // CRD with the service instance stuff, but only to this client, not the cluster

--- a/lib/openshift-rest-client.js
+++ b/lib/openshift-rest-client.js
@@ -72,7 +72,14 @@ const spec = JSON.parse(zlib.gunzipSync(fs.readFileSync(path.join(__dirname, 'sp
  */
 async function openshiftClient (settings = {}) {
   let config = settings.config;
-  const clientConfig = { backend: null, spec, getNames };
+
+  const clientConfig = { backend: null, /* spec, */ getNames };
+
+  if (!settings.loadSpec) {
+    console.log('using harcoded');
+    clientConfig.spec = spec;
+  }
+
   const kubeconfig = new KubeConfig();
 
   let fullyUserDefined = false;
@@ -144,6 +151,10 @@ async function openshiftClient (settings = {}) {
   }
 
   const client = new Client(clientConfig);
+  if (settings.loadSpec) {
+    console.log('using cluster one');
+    await client.loadSpec();
+  }
 
   // CRD with the service instance stuff, but only to this client, not the cluster
   client.addCustomResourceDefinition(serviceCatalogCRD);

--- a/lib/openshift-rest-client.js
+++ b/lib/openshift-rest-client.js
@@ -75,7 +75,7 @@ async function openshiftClient (settings = {}) {
 
   const clientConfig = { backend: null, /* spec, */ getNames };
 
-  if (!settings.loadSpec) {
+  if (!settings.loadSpecFromCluster) {
     clientConfig.spec = spec;
   }
 
@@ -150,7 +150,7 @@ async function openshiftClient (settings = {}) {
   }
 
   const client = new Client(clientConfig);
-  if (settings.loadSpec) {
+  if (settings.loadSpecFromCluster) {
     await client.loadSpec();
   }
 

--- a/lib/openshift-rest-client.js
+++ b/lib/openshift-rest-client.js
@@ -61,6 +61,7 @@ const spec = JSON.parse(zlib.gunzipSync(fs.readFileSync(path.join(__dirname, 'sp
  * Builds the rest client based on provided or default kubernetes configuration.
  *
  * @param {object} [settings] - settings object for the openshiftClient function
+ * @param {boolean} [settings.loadSpecFromCluster] - load the api spec from a remote cluster.  Defaults to false
  * @param {object|string} [settings.config] - custom config object.  String value will assume a config file location
  * @param {string} [settings.config.url] - Openshift cluster url
  * @param {string} [settings.config.authUrl] - Openshift Basic auth url

--- a/test/openshift-client-test.js
+++ b/test/openshift-client-test.js
@@ -212,3 +212,63 @@ test('openshift client tests - loadSpecFromCluster', async (t) => {
   t.ok(osClient.kubeconfig, 'client should have the kubeconfig object');
   t.end();
 });
+
+test('openshift client tests - loadSpecFromCluster - Fail to load remote and load default spec', async (t) => {
+  const openshiftRestClient = require('../');
+
+  openshiftRestClient.config.loadFromString(JSON.stringify(userDefinedConfig));
+  const settings = {
+    loadSpecFromCluster: true,
+    config: openshiftRestClient.config
+  };
+
+  nock('https://192.168.99.100:8443')
+    .matchHeader('authorization', 'Bearer zVBd1ZFeJqEAILJgimm4-gZJauaw3PW4EVqV_peEZ3U')
+    .get('/openapi/v2')
+    .reply(404, { message: 'Nope' })
+    .get('/swagger.json')
+    .reply(404, { message: 'Nope' });
+
+  const osClient = await openshiftRestClient.OpenshiftClient(settings);
+
+  t.pass('Failing client load should load default spec');
+
+  t.ok(osClient.apis['build.openshift.io'], 'client object should have a build object');
+  t.ok(osClient.apis.build, 'build object is aliased');
+
+  t.ok(osClient.apis['apps.openshift.io'], 'client object should have a apps object');
+  t.ok(osClient.apis.app, 'apps object is aliased to app');
+
+  t.ok(osClient.apis['authorization.openshift.io'], 'client object should have a authorization object');
+  t.ok(osClient.apis.authorization, 'authorization object is aliased to authorization');
+
+  t.ok(osClient.apis['image.openshift.io'], 'client object should have a image object');
+  t.ok(osClient.apis.image, 'image object is aliased to image');
+
+  t.ok(osClient.apis['network.openshift.io'], 'osClient object should have a network object');
+  t.ok(osClient.apis.network, 'network object is aliased to network');
+
+  t.ok(osClient.apis['oauth.openshift.io'], 'osClient object should have a oauth object');
+  t.ok(osClient.apis.oauth, 'oauth object is aliased to oauth');
+
+  t.ok(osClient.apis['project.openshift.io'], 'osClient object should have a project object');
+  t.ok(osClient.apis.project, 'project object is aliased to project');
+
+  t.ok(osClient.apis['quota.openshift.io'], 'osClient object should have a quota object');
+  t.ok(osClient.apis.quota, 'quota object is aliased to quota');
+
+  t.ok(osClient.apis['route.openshift.io'], 'osClient object should have a route object');
+  t.ok(osClient.apis.route, 'route object is aliased to route');
+
+  t.ok(osClient.apis['security.openshift.io'], 'osClient object should have a security object');
+  t.ok(osClient.apis.security, 'security object is aliased to security');
+
+  t.ok(osClient.apis['template.openshift.io'], 'osClient object should have a template object');
+  t.ok(osClient.apis.template, 'template object is aliased to template');
+
+  t.ok(osClient.apis['user.openshift.io'], 'osClient object should have a user object');
+  t.ok(osClient.apis.user, 'user object is aliased to user');
+
+  t.ok(osClient.kubeconfig, 'client should have the kubeconfig object');
+  t.end();
+});

--- a/test/openshift-client-test.js
+++ b/test/openshift-client-test.js
@@ -62,6 +62,65 @@ test('openshift client tests', (t) => {
   });
 });
 
+test('openshift client tests - loadSpec', (t) => {
+  // Need to stub the config loader for these tests
+  const stubbedConfig = (client) => {
+    return Promise.resolve(client);
+  };
+
+  const openshiftRestClient = proxyquire('../lib/openshift-rest-client', {
+    'kubernetes-client': {
+      config: {
+        fromKubeconfig: stubbedConfig
+      }
+    }
+  });
+
+  const osClient = openshiftRestClient({ loadSpec: true });
+  t.equal(osClient instanceof Promise, true, 'should return a Promise');
+
+  osClient.then((client) => {
+    t.ok(client.apis['build.openshift.io'], 'client object should have a build object');
+    t.ok(client.apis.build, 'build object is aliased');
+
+    t.ok(client.apis['apps.openshift.io'], 'client object should have a apps object');
+    t.ok(client.apis.app, 'apps object is aliased to app');
+
+    t.ok(client.apis['authorization.openshift.io'], 'client object should have a authorization object');
+    t.ok(client.apis.authorization, 'authorization object is aliased to authorization');
+
+    t.ok(client.apis['image.openshift.io'], 'client object should have a image object');
+    t.ok(client.apis.image, 'image object is aliased to image');
+
+    t.ok(client.apis['network.openshift.io'], 'client object should have a network object');
+    t.ok(client.apis.network, 'network object is aliased to network');
+
+    t.ok(client.apis['oauth.openshift.io'], 'client object should have a oauth object');
+    t.ok(client.apis.oauth, 'oauth object is aliased to oauth');
+
+    t.ok(client.apis['project.openshift.io'], 'client object should have a project object');
+    t.ok(client.apis.project, 'project object is aliased to project');
+
+    t.ok(client.apis['quota.openshift.io'], 'client object should have a quota object');
+    t.ok(client.apis.quota, 'quota object is aliased to quota');
+
+    t.ok(client.apis['route.openshift.io'], 'client object should have a route object');
+    t.ok(client.apis.route, 'route object is aliased to route');
+
+    t.ok(client.apis['security.openshift.io'], 'client object should have a security object');
+    t.ok(client.apis.security, 'security object is aliased to security');
+
+    t.ok(client.apis['template.openshift.io'], 'client object should have a template object');
+    t.ok(client.apis.template, 'template object is aliased to template');
+
+    t.ok(client.apis['user.openshift.io'], 'client object should have a user object');
+    t.ok(client.apis.user, 'user object is aliased to user');
+
+    t.ok(client.kubeconfig, 'client should have the kubeconfig object');
+    t.end();
+  });
+});
+
 test('test basic auth - username/password', async (t) => {
   const settings = {
     config: {


### PR DESCRIPTION
This adds an option, `loadSpecFromCluster`, that when true, will make a call to `/openapi/v2` or `swagger.json` on your remote cluster which will be loaded in the client.


By default, the client will load the spec file that we bundle, so there is no change for current users. 

The main motivation for this, is if someone has a cluster were they have added some operators that add extensions,  they would not be able to interact with those, since the spec file we load, only has the base kube and openshift api's.   If they used this new option,  then all the spec API's they have on their cluster will get loaded.

This type of thing is going to be needed for our nodeshift knative support. 

Open Question:  If both of those endpoints i named above fail to load,  do we just load the bundled spec instead?
 