### PR TITLE
Pass in an normal object as a Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,83 @@ For example, if you want to provide a different path to your configuration, you 
       });
     });
 
+You can also pass a plain object or a [KubeConfig](https://github.com/nodeshift/openshift-rest-client/blob/049059de652d9467b342f465a9394f321fc960bf/index.js#L23) object.
+
+An example of a plain object:
+
+```
+    const openshiftRestClient = require('openshift-rest-client').OpenshiftClient;
+    const k8Config = require('openshift-rest-client').config;
+
+    const config = {
+      apiVersion: 'v1',
+      kind: 'Config',
+      clusters: [
+          {
+            name: 'cluster',
+            cluster: {
+              skipTLSVerify: true,
+              server: 'server-time'
+            }
+          }
+        ],
+        users: [{ name: 'user', token: '123456' }],
+        contexts: [
+          {
+            context: {
+              user: 'user',
+              cluster: 'cluster'
+            },
+            name: 'context'
+          }
+        ],
+        'current-context': 'context'
+      };
+
+    openshiftRestClient({config}).then((client) => {
+      console.log(client);
+    });
+```
+
+An example of a KubeConfig object:
+
+```
+    const openshiftRestClient = require('openshift-rest-client').OpenshiftClient;
+    const k8Config = require('openshift-rest-client').config;
+
+    const config = {
+      apiVersion: 'v1',
+      kind: 'Config',
+      clusters: [
+          {
+            name: 'cluster',
+            cluster: {
+              skipTLSVerify: true,
+              server: 'server-time'
+            }
+          }
+        ],
+        users: [{ name: 'user', token: '123456' }],
+        contexts: [
+          {
+            context: {
+              user: 'user',
+              cluster: 'cluster'
+            },
+            name: 'context'
+          }
+        ],
+        'current-context': 'context'
+      };
+
+      k8Config.loadFromString(JSON.stringify(config));
+
+
+      openshiftRestClient({config: k8Config}).then((client) => {
+        console.log(client);
+      });
+```
+
 
 If you want to use a username/password combo to authenticate to Openshift, you might do something like this:
 

--- a/lib/openshift-rest-client.js
+++ b/lib/openshift-rest-client.js
@@ -62,7 +62,7 @@ const spec = JSON.parse(zlib.gunzipSync(fs.readFileSync(path.join(__dirname, 'sp
  *
  * @param {object} [settings] - settings object for the openshiftClient function
  * @param {boolean} [settings.loadSpecFromCluster] - load the api spec from a remote cluster.  Defaults to false
- * @param {object|string} [settings.config] - custom config object.  String value will assume a config file location
+ * @param {object|string} [settings.config] - custom config object(KubeConfig or object).  String value will assume a config file location.
  * @param {string} [settings.config.url] - Openshift cluster url
  * @param {string} [settings.config.authUrl] - Openshift Basic auth url
  * @param {object} [settings.config.auth] -
@@ -145,7 +145,7 @@ async function openshiftClient (settings = {}) {
       if (config instanceof KubeConfig) {
         // They passed in an actual KubeConfig object
         // No need to stringify and reload
-        clientConfig.backend = new Request({ config });
+        clientConfig.backend = new Request({ kubeconfig: config });
       } else {
         kubeconfig.loadFromString(JSON.stringify(config));
         clientConfig.backend = new Request({ kubeconfig });

--- a/lib/openshift-rest-client.js
+++ b/lib/openshift-rest-client.js
@@ -142,7 +142,14 @@ async function openshiftClient (settings = {}) {
         clientConfig.backend = new Request({ kubeconfig });
       }
     } else if (config.clusters) {
-      clientConfig.backend = new Request({ kubeconfig: config });
+      if (config instanceof KubeConfig) {
+        // They passed in an actual KubeConfig object
+        // No need to stringify and reload
+        clientConfig.backend = new Request({ config });
+      } else {
+        kubeconfig.loadFromString(JSON.stringify(config));
+        clientConfig.backend = new Request({ kubeconfig });
+      }
       fullyUserDefined = true;
     }
   } else {

--- a/test/openshift-client-test.js
+++ b/test/openshift-client-test.js
@@ -164,12 +164,38 @@ test('test different config with auth and no user/username', async (t) => {
   t.end();
 });
 
-test('test different config - user defined', async (t) => {
+test('test different config - user defined - as KubeConfig', async (t) => {
   const openshiftRestClient = require('../');
 
   openshiftRestClient.config.loadFromString(JSON.stringify(userDefinedConfig));
   const settings = {
     config: openshiftRestClient.config
+  };
+
+  await openshiftRestClient.OpenshiftClient(settings);
+  t.pass();
+  t.end();
+});
+
+test('test different config - different location as a string', async (t) => {
+  const openshiftRestClient = require('../');
+
+  const configLocation = `${__dirname}/test-config`;
+  const settings = {
+    config: configLocation
+  };
+
+  const client = await openshiftRestClient.OpenshiftClient(settings);
+  const { kubeconfig } = client;
+  t.equal(kubeconfig.currentContext, 'for-node-client-testing/192-168-99-100:8443/developer', 'current context is correctly loaded');
+  t.end();
+});
+
+test('test different config - user defined - as Regular Object', async (t) => {
+  const openshiftRestClient = require('../');
+
+  const settings = {
+    config: userDefinedConfig
   };
 
   await openshiftRestClient.OpenshiftClient(settings);


### PR DESCRIPTION
This adds the ability to pass in a custom config that is just a plain object.  A user can still create a KubeConfig object and pass that in.   This update would allow a user to pass in a normal object instead of going through the process of creating their own KubeConfig object.

