### PR TITLE
Removed authUrl, added auth url retrieval

### DIFF
--- a/.github/workflows/nodejs-ci-action.yml
+++ b/.github/workflows/nodejs-ci-action.yml
@@ -24,5 +24,20 @@ jobs:
     - run: npm ci
     - run: npm test
     - run: npx @pkgjs/support validate
-    - run: echo 'repo_token:' ${{ secrets.COVERALLS_GITHUB_TOKEN }} > ./.coveralls.yml
-    - run: node_modules/nyc/bin/nyc.js report --reporter=text-lcov | node_modules/coveralls/bin/coveralls.js
+    - run: node_modules/nyc/bin/nyc.js report --reporter=lcovonly
+    - name: Coveralls Parallel
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.github_token }}
+        flag-name: run-${{ matrix.node-version }}
+        parallel: true
+
+  finish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.github_token }}
+        parallel-finished: true

--- a/lib/authorization-server-request.js
+++ b/lib/authorization-server-request.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const request = require('request');
+
+const buildError = (requestError) => {
+  const err = new Error(requestError.message);
+  err.statusCode = requestError.code;
+  return err;
+};
+
+/**
+ * This method allows to retrieve automatically the authorization endpoint from the api
+ * compatible with OCP 3.x and OCP 4.x
+ * @param {string} url openshift platform api url
+ * @param {boolean} insecureSkipTlsVerify validate ssl
+ */
+const getAuthUrlFromOCP = async (url, insecureSkipTlsVerify = true) => {
+  const req = {
+    method: 'GET',
+    url: `${url}/.well-known/oauth-authorization-server`,
+    strictSSL: insecureSkipTlsVerify
+  };
+
+  return new Promise((resolve, reject) => {
+    request(req, (err, resp, body) => {
+      if (err) return reject(buildError(err));
+
+      if (resp.statusCode === 404) {
+        return reject(new Error('404 Unable to get the auth url'));
+      }
+      const bodyJSON = JSON.parse(body);
+      if (bodyJSON.authorization_endpoint) {
+        return resolve(`${bodyJSON.authorization_endpoint}?response_type=token&client_id=openshift-challenging-client`);
+      } else {
+        return reject(new Error(`Unable to retrieve the token_endpoint for ${resp.request.uri.host}. Cannot obtain token_endpoint from response.`));
+      }
+    });
+  });
+};
+
+module.exports = {
+  getAuthUrlFromOCP
+};

--- a/lib/basic-auth-request.js
+++ b/lib/basic-auth-request.js
@@ -7,10 +7,40 @@ const buildError = (requestError) => {
   err.statusCode = requestError.code;
   return err;
 };
+/**
+ * This method allows to retrieve automatically the authorization endpoint from the api
+ * compatible with OCP 3.x and OCP 4.x
+ * @param {string} url openshift platform api url
+ * @param {boolean} insecureSkipTlsVerify validate ssl
+ */
+const getAuthUrlFromOCP = async (url, insecureSkipTlsVerify = true) => {
+  const req = {
+    method: 'GET',
+    url: `${url}/.well-known/oauth-authorization-server`,
+    strictSSL: insecureSkipTlsVerify
+  };
+
+  return new Promise((resolve, reject) => {
+    request(req, (err, resp, body) => {
+      if (err) return reject(buildError(err));
+
+      if (resp.statusCode === 404) {
+        return reject(new Error('404 Unable to get the auth url'));
+      }
+      const bodyJSON = JSON.parse(body);
+      if (bodyJSON.authorization_endpoint) {
+        return resolve(`${bodyJSON.authorization_endpoint}?response_type=token&client_id=openshift-challenging-client`);
+      } else {
+        return reject(new Error(`Unable to retrieve the token_endpoint for ${resp.request.uri.host}. Cannot obtain token_endpoint from response.`));
+      }
+    });
+  });
+};
 
 async function getTokenFromBasicAuth (settings) {
+  // Get the Auth URL from Openshift endpoint
+  const authUrl = await getAuthUrlFromOCP(settings.url, 'insecureSkipTlsVerify' in settings ? !settings.insecureSkipTlsVerify : true);
   return new Promise((resolve, reject) => {
-    const authUrl = `${settings.authUrl ? settings.authUrl : settings.url}/oauth/authorize?response_type=token&client_id=openshift-challenging-client`;
     const credentials = `${settings.user}:${settings.password}`;
     const auth = `Basic ${Buffer.from(credentials).toString('base64')}`;
 

--- a/lib/basic-auth-request.js
+++ b/lib/basic-auth-request.js
@@ -1,40 +1,12 @@
 'use strict';
 
 const request = require('request');
+const { getAuthUrlFromOCP } = require('./authorization-server-request');
 
 const buildError = (requestError) => {
   const err = new Error(requestError.message);
   err.statusCode = requestError.code;
   return err;
-};
-/**
- * This method allows to retrieve automatically the authorization endpoint from the api
- * compatible with OCP 3.x and OCP 4.x
- * @param {string} url openshift platform api url
- * @param {boolean} insecureSkipTlsVerify validate ssl
- */
-const getAuthUrlFromOCP = async (url, insecureSkipTlsVerify = true) => {
-  const req = {
-    method: 'GET',
-    url: `${url}/.well-known/oauth-authorization-server`,
-    strictSSL: insecureSkipTlsVerify
-  };
-
-  return new Promise((resolve, reject) => {
-    request(req, (err, resp, body) => {
-      if (err) return reject(buildError(err));
-
-      if (resp.statusCode === 404) {
-        return reject(new Error('404 Unable to get the auth url'));
-      }
-      const bodyJSON = JSON.parse(body);
-      if (bodyJSON.authorization_endpoint) {
-        return resolve(`${bodyJSON.authorization_endpoint}?response_type=token&client_id=openshift-challenging-client`);
-      } else {
-        return reject(new Error(`Unable to retrieve the token_endpoint for ${resp.request.uri.host}. Cannot obtain token_endpoint from response.`));
-      }
-    });
-  });
 };
 
 async function getTokenFromBasicAuth (settings) {

--- a/lib/openshift-rest-client.js
+++ b/lib/openshift-rest-client.js
@@ -64,7 +64,6 @@ const spec = JSON.parse(zlib.gunzipSync(fs.readFileSync(path.join(__dirname, 'sp
  * @param {boolean} [settings.loadSpecFromCluster] - load the api spec from a remote cluster.  Defaults to false
  * @param {object|string} [settings.config] - custom config object(KubeConfig or object).  String value will assume a config file location.
  * @param {string} [settings.config.url] - Openshift cluster url
- * @param {string} [settings.config.authUrl] - Openshift Basic auth url
  * @param {object} [settings.config.auth] -
  * @param {string} [settings.config.auth.username] - username to authenticate to Openshift
  * @param {string} [settings.config.auth.password] - password to authenticate to Openshift
@@ -102,7 +101,7 @@ async function openshiftClient (settings = {}) {
         const password = config.auth.password || config.auth.pass;
 
         const accessToken = await getTokenFromBasicAuth({ insecureSkipTlsVerify, url, user, password, authUrl });
-        const clusterUrl = authUrl || url;
+        const clusterUrl = url;
         // Create clusterName from clusterUrl by removing 'https://'
         const clusterName = clusterUrl.replace(/(^\w+:|^)\/\//, '');
         config = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6909,9 +6909,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
+      "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
       "dev": true
     },
     "inquirer": {

--- a/test/authorization-server-request-test.js
+++ b/test/authorization-server-request-test.js
@@ -1,0 +1,126 @@
+'use strict';
+
+/* eslint standard/no-callback-literal: "off" */
+
+const test = require('tape');
+const proxyquire = require('proxyquire');
+
+test('authorization server request', (t) => {
+  const authorizationServerRequest = proxyquire('../lib/authorization-server-request', {
+    request: (requestObject, cb) => {
+      t.equal(requestObject.strictSSL, false, 'should be false');
+      return cb(null, {
+        statusCode: 200
+      },
+      '{"authorization_endpoint": "http://"}');
+    }
+  });
+
+  const p = authorizationServerRequest.getAuthUrlFromOCP('http://', false);
+
+  t.equal(p instanceof Promise, true, 'is an Promise');
+
+  p.then((url) => {
+    t.equal(url, 'http://?response_type=token&client_id=openshift-challenging-client', 'should be equal');
+    t.end();
+  });
+});
+
+test('authorization server request without insecureSkipTlsVerify', (t) => {
+  const authorizationServerRequest = proxyquire('../lib/authorization-server-request', {
+    request: (requestObject, cb) => {
+      t.equal(requestObject.strictSSL, true, 'should be true');
+      return cb(null, {
+        statusCode: 200
+      },
+      '{"authorization_endpoint": "http://"}');
+    }
+  });
+
+  const p = authorizationServerRequest.getAuthUrlFromOCP('http://');
+
+  t.equal(p instanceof Promise, true, 'is an Promise');
+
+  p.then((url) => {
+    t.equal(url, 'http://?response_type=token&client_id=openshift-challenging-client', 'should be equal');
+    t.end();
+  });
+});
+
+test('authorization server request with empty body', (t) => {
+  const authorizationServerRequest = proxyquire('../lib/authorization-server-request', {
+    request: (requestObject, cb) => {
+      t.equal(requestObject.strictSSL, false, 'should be false');
+      return cb(null, {
+        statusCode: 200,
+        request: {
+          uri: {
+            host: 'https://'
+          }
+        }
+      },
+      '{}');
+    }
+  });
+
+  const p = authorizationServerRequest.getAuthUrlFromOCP('http://', false);
+
+  t.equal(p instanceof Promise, true, 'is an Promise');
+
+  p.catch((error) => {
+    t.equal(error.message,
+      'Unable to retrieve the token_endpoint for https://. Cannot obtain token_endpoint from response.',
+      'should be equal');
+    t.end();
+  });
+});
+
+test('authorization server request with 404 status code', (t) => {
+  const authorizationServerRequest = proxyquire('../lib/authorization-server-request', {
+    request: (requestObject, cb) => {
+      t.equal(requestObject.strictSSL, false, 'should be false');
+      return cb(null, {
+        statusCode: 404,
+        request: {
+          uri: {
+            host: 'https://'
+          }
+        }
+      });
+    }
+  });
+
+  const p = authorizationServerRequest.getAuthUrlFromOCP('http://', false);
+
+  t.equal(p instanceof Promise, true, 'is an Promise');
+
+  p.catch((error) => {
+    t.equal(error.message,
+      '404 Unable to get the auth url',
+      'should be equal');
+    t.end();
+  });
+});
+
+test('authorization server request with error', (t) => {
+  const authorizationServerRequest = proxyquire('../lib/authorization-server-request', {
+    request: (requestObject, cb) => {
+      t.equal(requestObject.strictSSL, false, 'should be false');
+      return cb({
+        message: 'message',
+        errorCode: 'code'
+      }, null, null);
+    }
+  });
+
+  const p = authorizationServerRequest.getAuthUrlFromOCP('http://', false);
+
+  t.equal(p instanceof Promise, true, 'is an Promise');
+
+  p.catch((error) => {
+    t.equal(error.message,
+      'message',
+      'should be equal');
+    t.end();
+  });
+});

--- a/test/basic-auth-request-test.js
+++ b/test/basic-auth-request-test.js
@@ -7,6 +7,12 @@ const proxyquire = require('proxyquire');
 
 test('basic auth request', (t) => {
   const basicAuthRequest = proxyquire('../lib/basic-auth-request', {
+    './authorization-server-request': {
+      getAuthUrlFromOCP: (url, insecureSkipTlsVerify) => {
+        t.equal(url, 'http://');
+        return Promise.resolve('https://');
+      }
+    },
     request: (requestObject, cb) => {
       t.equal(requestObject.strictSSL, false, 'should be false');
       return cb(null, {
@@ -16,8 +22,7 @@ test('basic auth request', (t) => {
             hash: '#access_token=9jXMEO87d7Rtf6FVQTFjumwIDbGeMzAtr2U010Z_ZG0&expires_in=86400&scope=user%3Afull&token_type=Bearer'
           }
         }
-      },
-      '{"authorization_endpoint": "http://"}');
+      });
     }
   });
 
@@ -38,47 +43,23 @@ test('basic auth request', (t) => {
   });
 });
 
-test('basic auth request with empty body', (t) => {
-  const basicAuthRequest = proxyquire('../lib/basic-auth-request', {
-    request: (requestObject, cb) => {
-      t.equal(requestObject.strictSSL, false, 'should be false');
-      return cb(null, {
-        statusCode: 200,
-        request: {
-          uri: {
-            hash: '#access_token=9jXMEO87d7Rtf6FVQTFjumwIDbGeMzAtr2U010Z_ZG0&expires_in=86400&scope=user%3Afull&token_type=Bearer'
-          }
-        }
-      },
-      '{}');
-    }
-  });
-
-  const settings = {
-    url: 'http://',
-    user: 'username',
-    password: 'password',
-    insecureSkipTlsVerify: true
-  };
-
-  const p = basicAuthRequest.getTokenFromBasicAuth(settings);
-
-  t.equal(p instanceof Promise, true, 'is an Promise');
-
-  p.catch((error) => {
-    t.equal(error.message,
-      'Unable to retrieve the token_endpoint for undefined. Cannot obtain token_endpoint from response.',
-      'should be equal');
-    t.end();
-  });
-});
-
 test('basic auth request with 404 status code', (t) => {
   const basicAuthRequest = proxyquire('../lib/basic-auth-request', {
+    './authorization-server-request': {
+      getAuthUrlFromOCP: (url, insecureSkipTlsVerify) => {
+        t.equal(url, 'http://');
+        return Promise.resolve('https://');
+      }
+    },
     request: (requestObject, cb) => {
       t.equal(requestObject.strictSSL, false, 'should be false');
       return cb(null, {
-        statusCode: 404
+        statusCode: 404,
+        request: {
+          uri: {
+            host: 'https://'
+          }
+        }
       });
     }
   });
@@ -96,7 +77,47 @@ test('basic auth request with 404 status code', (t) => {
 
   p.catch((error) => {
     t.equal(error.message,
-      '404 Unable to get the auth url',
+      'Unable to authenticate user username to https://. Cannot obtain access token from response.',
+      'should be equal');
+    t.end();
+  });
+});
+
+test('basic auth request with 401 status code', (t) => {
+  const basicAuthRequest = proxyquire('../lib/basic-auth-request', {
+    './authorization-server-request': {
+      getAuthUrlFromOCP: (url, insecureSkipTlsVerify) => {
+        t.equal(url, 'http://');
+        return Promise.resolve('https://');
+      }
+    },
+    request: (requestObject, cb) => {
+      t.equal(requestObject.strictSSL, false, 'should be false');
+      return cb(null, {
+        statusCode: 401,
+        request: {
+          uri: {
+            host: 'https://'
+          }
+        }
+      });
+    }
+  });
+
+  const settings = {
+    url: 'http://',
+    user: 'username',
+    password: 'password',
+    insecureSkipTlsVerify: true
+  };
+
+  const p = basicAuthRequest.getTokenFromBasicAuth(settings);
+
+  t.equal(p instanceof Promise, true, 'is an Promise');
+
+  p.catch((error) => {
+    t.equal(error.message,
+      '401 Unable to authenticate user username',
       'should be equal');
     t.end();
   });
@@ -104,6 +125,12 @@ test('basic auth request with 404 status code', (t) => {
 
 test('basic auth request with request error', (t) => {
   const basicAuthRequest = proxyquire('../lib/basic-auth-request', {
+    './authorization-server-request': {
+      getAuthUrlFromOCP: (url, insecureSkipTlsVerify) => {
+        t.equal(url, undefined);
+        return Promise.resolve('https://');
+      }
+    },
     request: (requestObject, cb) => {
       return cb({ message: 'Error' }, {});
     }

--- a/test/basic-auth-request-test.js
+++ b/test/basic-auth-request-test.js
@@ -16,7 +16,8 @@ test('basic auth request', (t) => {
             hash: '#access_token=9jXMEO87d7Rtf6FVQTFjumwIDbGeMzAtr2U010Z_ZG0&expires_in=86400&scope=user%3Afull&token_type=Bearer'
           }
         }
-      });
+      },
+      '{"authorization_endpoint": "http://"}');
     }
   });
 
@@ -52,96 +53,6 @@ test('basic auth request with request error', (t) => {
 
   p.catch((error) => {
     t.equal(error.message, 'Error', 'should be equal');
-    t.end();
-  });
-});
-
-test('basic auth request with 401 error', (t) => {
-  const basicAuthRequest = proxyquire('../lib/basic-auth-request', {
-    request: (requestObject, cb) => {
-      return cb(null, {
-        statusCode: 401
-      });
-    }
-  });
-
-  const settings = {
-    user: 'username'
-  };
-
-  const p = basicAuthRequest.getTokenFromBasicAuth(settings);
-
-  t.equal(p instanceof Promise, true, 'is an Promise');
-
-  p.catch((error) => {
-    t.equal(error.message, '401 Unable to authenticate user username', 'should be equal');
-    t.end();
-  });
-});
-
-test('basic auth request with defined auth url', (t) => {
-  const basicAuthRequest = proxyquire('../lib/basic-auth-request', {
-    request: (requestObject, cb) => {
-      t.true(requestObject.url.includes('https://test'), 'Unexpected auth url value');
-      return cb(null, {
-        statusCode: 200,
-        request: {
-          uri: {
-            hash: '#access_token=9jXMEO87d7Rtf6FVQTFjumwIDbGeMzAtr2U010Z_ZG0&expires_in=86400&scope=user%3Afull&token_type=Bearer'
-          }
-        }
-      });
-    }
-  });
-
-  const settings = {
-    url: 'http://',
-    authUrl: 'https://test',
-    user: 'username',
-    password: 'password',
-    insecureSkipTlsVerify: true
-  };
-
-  const p = basicAuthRequest.getTokenFromBasicAuth(settings);
-
-  t.equal(p instanceof Promise, true, 'is an Promise');
-
-  p.then((token) => {
-    t.equal(token, '9jXMEO87d7Rtf6FVQTFjumwIDbGeMzAtr2U010Z_ZG0', 'should be equal');
-    t.end();
-  });
-});
-
-test('basic auth request with missing hash', (t) => {
-  const basicAuthRequest = proxyquire('../lib/basic-auth-request', {
-    request: (requestObject, cb) => {
-      t.true(requestObject.url.includes('https://test'), 'Unexpected auth url value');
-      return cb(null, {
-        statusCode: 200,
-        request: {
-          uri: {
-            hash: undefined,
-            host: 'testhost'
-          }
-        }
-      });
-    }
-  });
-
-  const settings = {
-    url: 'http://',
-    authUrl: 'https://test',
-    user: 'username',
-    password: 'password',
-    insecureSkipTlsVerify: true
-  };
-
-  const p = basicAuthRequest.getTokenFromBasicAuth(settings);
-
-  t.equal(p instanceof Promise, true, 'is an Promise');
-
-  p.catch((error) => {
-    t.equal(error.message, 'Unable to authenticate user username to testhost. Cannot obtain access token from response.', 'should be equal');
     t.end();
   });
 });

--- a/test/basic-auth-request-test.js
+++ b/test/basic-auth-request-test.js
@@ -38,6 +38,70 @@ test('basic auth request', (t) => {
   });
 });
 
+test('basic auth request with empty body', (t) => {
+  const basicAuthRequest = proxyquire('../lib/basic-auth-request', {
+    request: (requestObject, cb) => {
+      t.equal(requestObject.strictSSL, false, 'should be false');
+      return cb(null, {
+        statusCode: 200,
+        request: {
+          uri: {
+            hash: '#access_token=9jXMEO87d7Rtf6FVQTFjumwIDbGeMzAtr2U010Z_ZG0&expires_in=86400&scope=user%3Afull&token_type=Bearer'
+          }
+        }
+      },
+      '{}');
+    }
+  });
+
+  const settings = {
+    url: 'http://',
+    user: 'username',
+    password: 'password',
+    insecureSkipTlsVerify: true
+  };
+
+  const p = basicAuthRequest.getTokenFromBasicAuth(settings);
+
+  t.equal(p instanceof Promise, true, 'is an Promise');
+
+  p.catch((error) => {
+    t.equal(error.message,
+      'Unable to retrieve the token_endpoint for undefined. Cannot obtain token_endpoint from response.',
+      'should be equal');
+    t.end();
+  });
+});
+
+test('basic auth request with 404 status code', (t) => {
+  const basicAuthRequest = proxyquire('../lib/basic-auth-request', {
+    request: (requestObject, cb) => {
+      t.equal(requestObject.strictSSL, false, 'should be false');
+      return cb(null, {
+        statusCode: 404
+      });
+    }
+  });
+
+  const settings = {
+    url: 'http://',
+    user: 'username',
+    password: 'password',
+    insecureSkipTlsVerify: true
+  };
+
+  const p = basicAuthRequest.getTokenFromBasicAuth(settings);
+
+  t.equal(p instanceof Promise, true, 'is an Promise');
+
+  p.catch((error) => {
+    t.equal(error.message,
+      '404 Unable to get the auth url',
+      'should be equal');
+    t.end();
+  });
+});
+
 test('basic auth request with request error', (t) => {
   const basicAuthRequest = proxyquire('../lib/basic-auth-request', {
     request: (requestObject, cb) => {


### PR DESCRIPTION
Hi, I have made several changes to the current code, 

I was able to discover that authUrl was not working fine. The current code is fine but there is a typo in this line:
https://github.com/nodeshift/openshift-rest-client/blob/master/lib/openshift-rest-client.js#L105
clusterUrl, should be always url. with the current code you always retrieve a 404 getting the projects and so on.

Researching the OC CLI, we realised that there is an endpoint  located at: 
`/.well-known/oauth-authorization-server` that allows you to get the `authorization_endpoint`.
Output:
`{
    "issuer": "https://URL",
    "authorization_endpoint": "https://URL/oauth/authorize",
    "token_endpoint": "https://URL/oauth/token",
    "scopes_supported": [
        "user:check-access",
        "user:full",
        "user:info",
        "user:list-projects",
        "user:list-scoped-projects"
    ],
    "response_types_supported": [
        "code",
        "token"
    ],
    "grant_types_supported": [
        "authorization_code",
        "implicit"
    ],
    "code_challenge_methods_supported": [
        "plain",
        "S256"
    ]
}`

With this information there is no longer needed the authUrl settings param, because you can get automatically from the api endpoint. This works in OCP 3.X and OCP 4.X