### PR TITLE
fix: safe join for urls

### DIFF
--- a/lib/authorization-server-request.js
+++ b/lib/authorization-server-request.js
@@ -17,7 +17,7 @@ const buildError = (requestError) => {
 const getAuthUrlFromOCP = async (url, insecureSkipTlsVerify = true) => {
   const req = {
     method: 'GET',
-    url: `${url}/.well-known/oauth-authorization-server`,
+    url: new URL('/.well-known/oauth-authorization-server', url).toString(),
     strictSSL: insecureSkipTlsVerify
   };
 

--- a/lib/basic-auth-request.js
+++ b/lib/basic-auth-request.js
@@ -15,7 +15,7 @@ async function getUserFromAuthToken (settings) {
   return new Promise((resolve, reject) => {
     const req = {
       method: 'GET',
-      url: `${settings.url}/apis/user.openshift.io/v1/users/~`,
+      url: new URL('/apis/user.openshift.io/v1/users/~', settings.url).toString(),
       auth: {
         bearer: settings.token
       },


### PR DESCRIPTION
Addresses #262 

This is a little noisy since the previous URL used in tests (`http://`) isn't valid when passed to the `new URL` constructor that's used to perform the new safe URL construction. This means all tests needed that URL change.