### PR TITLE
feat:(src!): Make the loadSpecFromCluster setting true by default

### DIFF
--- a/lib/openshift-rest-client.js
+++ b/lib/openshift-rest-client.js
@@ -61,7 +61,7 @@ const spec = JSON.parse(zlib.gunzipSync(fs.readFileSync(path.join(__dirname, 'sp
  * Builds the rest client based on provided or default kubernetes configuration.
  *
  * @param {object} [settings] - settings object for the openshiftClient function
- * @param {boolean} [settings.loadSpecFromCluster] - load the api spec from a remote cluster.  Defaults to false
+ * @param {boolean} [settings.loadSpecFromCluster] - load the api spec from a remote cluster.  Defaults to true
  * @param {object|string} [settings.config] - custom config object(KubeConfig or object).  String value will assume a config file location.
  * @param {string} [settings.config.url] - Openshift cluster url
  * @param {object} [settings.config.auth] -
@@ -73,10 +73,12 @@ const spec = JSON.parse(zlib.gunzipSync(fs.readFileSync(path.join(__dirname, 'sp
  */
 async function openshiftClient (settings = {}) {
   let config = settings.config;
+  // Default the load spec from cluster to true
+  const { loadSpecFromCluster = true } = settings;
 
   const clientConfig = { backend: null, /* spec, */ getNames };
 
-  if (!settings.loadSpecFromCluster) {
+  if (!loadSpecFromCluster) {
     clientConfig.spec = spec;
   }
 
@@ -166,7 +168,7 @@ async function openshiftClient (settings = {}) {
   }
 
   let client = new Client(clientConfig);
-  if (settings.loadSpecFromCluster) {
+  if (loadSpecFromCluster) {
     try {
       await client.loadSpec();
     } catch (err) {

--- a/test/binary-build-test.js
+++ b/test/binary-build-test.js
@@ -12,7 +12,8 @@ const userDefinedConfig = require('./test-config.json');
 test('instantiateBinary - buildconfig', async (t) => {
   openshiftRestClient.config.loadFromString(JSON.stringify(userDefinedConfig));
   const settings = {
-    config: openshiftRestClient.config
+    config: openshiftRestClient.config,
+    loadSpecFromCluster: false
   };
 
   const client = await openshiftRestClient.OpenshiftClient(settings);


### PR DESCRIPTION
BREAKING_CHANGE:

This changes the default value of loadSpecFromCluster to true instead of false.  This requires a semver-major update

The motivation is that most people will want to just load the API's their cluster has access to.  If they can't do that, then it does fallback to load the included spec file.  This could be another investigation,  to see if we really need this fallback.  If not, it would get rid of a somewhat large file.

