### PR TITLE
Replace request with undici

### DIFF
--- a/lib/authorization-server-request.js
+++ b/lib/authorization-server-request.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const request = require('request');
+const { Client } = require('undici');
 
 const buildError = (requestError) => {
   const err = new Error(requestError.message);
@@ -15,25 +15,28 @@ const buildError = (requestError) => {
  * @param {boolean} insecureSkipTlsVerify validate ssl
  */
 const getAuthUrlFromOCP = async (url, insecureSkipTlsVerify = true) => {
-  const req = {
-    method: 'GET',
-    url: new URL('/.well-known/oauth-authorization-server', url).toString(),
-    strictSSL: insecureSkipTlsVerify
-  };
-
   return new Promise((resolve, reject) => {
-    request(req, (err, resp, body) => {
-      if (err) return reject(buildError(err));
-
-      if (resp.statusCode === 404) {
+    const client = new Client(url, {
+      connect: {
+        strictSSL: insecureSkipTlsVerify
+      }
+    });
+    const requestOptions = {
+      path: '.well-known/oauth-authorization-server',
+      method: 'GET'
+    };
+    client.request(requestOptions).then(async (responseData) => {
+      if (responseData.statusCode === 404) {
         return reject(new Error('404 Unable to get the auth url'));
       }
-      const bodyJSON = JSON.parse(body);
+      const bodyJSON = await responseData.body.json();
       if (bodyJSON.authorization_endpoint) {
         return resolve(`${bodyJSON.authorization_endpoint}?response_type=token&client_id=openshift-challenging-client`);
       } else {
-        return reject(new Error(`Unable to retrieve the token_endpoint for ${resp.request.uri.host}. Cannot obtain token_endpoint from response.`));
+        return reject(new Error(`Unable to retrieve the token_endpoint for ${url}. Cannot obtain token_endpoint from response.`));
       }
+    }).catch((err) => {
+      return reject(buildError(err));
     });
   });
 };

--- a/lib/basic-auth-request.js
+++ b/lib/basic-auth-request.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const request = require('request');
+const { Client } = require('undici');
 const { getAuthUrlFromOCP } = require('./authorization-server-request');
 
 const buildError = (requestError) => {
@@ -13,23 +13,23 @@ const buildError = (requestError) => {
 // This will return a User Openshift Object
 async function getUserFromAuthToken (settings) {
   return new Promise((resolve, reject) => {
-    const req = {
+    const client = new Client(settings.url, {
+      connect: {
+        strictSSL: 'insecureSkipTlsVerify' in settings ? !settings.insecureSkipTlsVerify : true
+      }
+    });
+    const requestOptions = {
+      path: 'apis/user.openshift.io/v1/users/~',
       method: 'GET',
-      url: new URL('/apis/user.openshift.io/v1/users/~', settings.url).toString(),
-      auth: {
-        bearer: settings.token
-      },
-      strictSSL: 'insecureSkipTlsVerify' in settings ? !settings.insecureSkipTlsVerify : true
+      headers: { Authorization: `Bearer ${settings.token}` }
     };
-
-    request(req, (err, resp, body) => {
-      if (err) return reject(buildError(err));
-
-      if (resp.statusCode === 401) {
+    client.request(requestOptions).then(async (responseData) => {
+      if (responseData.statusCode === 401) {
         return reject(new Error(`401 Unable to authenticate with token ${settings.token}`));
       }
-
-      return resolve(JSON.parse(body));
+      return resolve(await responseData.body.json());
+    }).catch((err) => {
+      return reject(buildError(err));
     });
   });
 }
@@ -41,6 +41,19 @@ async function getTokenFromBasicAuth (settings) {
     const credentials = `${settings.user}:${settings.password}`;
     const auth = `Basic ${Buffer.from(credentials).toString('base64')}`;
 
+    const client = new Client(authUrl, {
+      connect: {
+        strictSSL: 'insecureSkipTlsVerify' in settings ? !settings.insecureSkipTlsVerify : true
+      }
+    });
+
+    const requestOptions = {
+      path: authUrl,
+      method: 'GET',
+      headers: { Authorization: auth }
+    };
+
+    /*
     const req = {
       method: 'GET',
       url: authUrl,
@@ -49,7 +62,26 @@ async function getTokenFromBasicAuth (settings) {
       },
       strictSSL: 'insecureSkipTlsVerify' in settings ? !settings.insecureSkipTlsVerify : true
     };
+    */
+    client.request(requestOptions).then(async (responseData) => {
+      if (responseData.statusCode === 401) {
+        return reject(new Error(`401 Unable to authenticate user ${settings.user}`));
+      }
+      const body = await responseData.body.json();
+      const hash = body.uri.hash;
+      if (hash) {
+        const startIndex = hash.indexOf('=') + 1;
+        const stopIndex = hash.indexOf('&');
+        const accessToken = hash.slice(startIndex, stopIndex);
+        return resolve(accessToken);
+      } else {
+        return reject(new Error(`Unable to authenticate user ${settings.user} to ${settings.url}. Cannot obtain access token from response.`));
+      }
+    }).catch((err) => {
+      return reject(buildError(err));
+    });
 
+    /*
     request(req, (err, resp, body) => {
       if (err) return reject(buildError(err));
 
@@ -67,6 +99,7 @@ async function getTokenFromBasicAuth (settings) {
         return reject(new Error(`Unable to authenticate user ${settings.user} to ${resp.request.uri.host}. Cannot obtain access token from response.`));
       }
     });
+    */
   });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "kubernetes-client": "9.0.0",
-        "request": "~2.88.2"
+        "undici": "^5.11.0"
       },
       "devDependencies": {
         "coveralls": "~3.1.1",
@@ -1390,6 +1390,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -9295,6 +9306,14 @@
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
@@ -10026,6 +10045,17 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
       "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ=="
+    },
+    "node_modules/undici": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.11.0.tgz",
+      "integrity": "sha512-oWjWJHzFet0Ow4YZBkyiJwiK5vWqEYoH7BINzJAJOLedZ++JpAlCbUktW2GQ2DS2FpKmxD/JMtWUUWl1BtghGw==",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.18"
+      }
     },
     "node_modules/unified": {
       "version": "9.2.2",
@@ -11963,6 +11993,14 @@
             "lru-cache": "^6.0.0"
           }
         }
+      }
+    },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "requires": {
+        "streamsearch": "^1.1.0"
       }
     },
     "bytes": {
@@ -18028,6 +18066,11 @@
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
     },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+    },
     "strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
@@ -18628,6 +18671,14 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
       "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ=="
+    },
+    "undici": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.11.0.tgz",
+      "integrity": "sha512-oWjWJHzFet0Ow4YZBkyiJwiK5vWqEYoH7BINzJAJOLedZ++JpAlCbUktW2GQ2DS2FpKmxD/JMtWUUWl1BtghGw==",
+      "requires": {
+        "busboy": "^1.6.0"
+      }
     },
     "unified": {
       "version": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "kubernetes-client": "9.0.0",
-    "request": "~2.88.2"
+    "undici": "^5.11.0"
   },
   "devDependencies": {
     "coveralls": "~3.1.1",


### PR DESCRIPTION
These commit replace `request` with `undici`.

----
Apart from the tests passing, a manual test was performed using:

First login using `oc`:
```console
$ oc login
You must obtain an API token by visiting https://oauth-openshift.apps.sandbox.x8i5.p1.openshiftapps.com/oauth/token/request
$ oc login --token=<token>
Logged into "https://api.sandbox.x8i5.p1.openshiftapps.com:6443" as "dbevenius" using the token provided.

You have one project on this server: "dbevenius-dev"

Using project "dbevenius-dev".
```
Then run one of the examples from the README.md:
```console
$ node - <<HERE
const openshiftRestClient = require('./index.js').OpenshiftClient;

openshiftRestClient().then((client) => {
  client.apis['project.openshift.io'].v1.projects.get().then((response) => {
    console.log(response.body);
  });
});
HERE
{
  kind: 'ProjectList',
  apiVersion: 'project.openshift.io/v1',
  metadata: {},
  items: [ { metadata: [Object], spec: [Object], status: [Object] } ]
}
```