### PR TITLE
fix: fix path on requestOptions

### DIFF
--- a/lib/authorization-server-request.js
+++ b/lib/authorization-server-request.js
@@ -22,7 +22,7 @@ const getAuthUrlFromOCP = async (url, insecureSkipTlsVerify = true) => {
       }
     });
     const requestOptions = {
-      path: '.well-known/oauth-authorization-server',
+      path: '/.well-known/oauth-authorization-server',
       method: 'GET'
     };
     client.request(requestOptions).then(async (responseData) => {

--- a/lib/basic-auth-request.js
+++ b/lib/basic-auth-request.js
@@ -19,7 +19,7 @@ async function getUserFromAuthToken (settings) {
       }
     });
     const requestOptions = {
-      path: 'apis/user.openshift.io/v1/users/~',
+      path: '/apis/user.openshift.io/v1/users/~',
       method: 'GET',
       headers: { Authorization: `Bearer ${settings.token}` }
     };

--- a/test/authorization-server-request-test.js
+++ b/test/authorization-server-request-test.js
@@ -2,7 +2,7 @@
 
 const test = require('tape');
 const proxyquire = require('proxyquire');
-const BASE_URL = 'http://some.cluster.com:6443/';
+const BASE_URL = 'http://some.cluster.com:6443';
 
 function create (MockClient) {
   return proxyquire('../lib/authorization-server-request', {
@@ -58,7 +58,7 @@ test('authorization server request URL join safety', (t) => {
     }
 
     request (options) {
-      t.equal(this.url + options.path, `${BASE_URL}.well-known/oauth-authorization-server`);
+      t.equal(this.url + options.path, `${BASE_URL}/.well-known/oauth-authorization-server`);
       return new Promise((resolve, reject) => {
         resolve({
           statusCode: 200,

--- a/test/basic-auth-request-test.js
+++ b/test/basic-auth-request-test.js
@@ -2,7 +2,7 @@
 
 const test = require('tape');
 const proxyquire = require('proxyquire');
-const BASE_URL = 'http://some.cluster.com:6443/';
+const BASE_URL = 'http://some.cluster.com:6443';
 
 test('basic auth request', (t) => {
   class MockClient {
@@ -278,7 +278,7 @@ test('get user from token URL join safety', (t) => {
     }
 
     request (options) {
-      t.equal(this.url + options.path, `${BASE_URL}apis/user.openshift.io/v1/users/~`);
+      t.equal(this.url + options.path, `${BASE_URL}/apis/user.openshift.io/v1/users/~`);
       return new Promise((resolve, reject) => {
         resolve({
           statusCode: 200,


### PR DESCRIPTION
This code try to resolve the follow issue (https://github.com/nodeshift/openshift-rest-client/issues/323):

`Error: path must be an absolute URL or start with a slash at buildError`