### PR TITLE
Use `rejectUnauthorized` instead of `strictSSL`

### DIFF
--- a/lib/basic-auth-request.js
+++ b/lib/basic-auth-request.js
@@ -15,7 +15,7 @@ async function getUserFromAuthToken (settings) {
   return new Promise((resolve, reject) => {
     const client = new Client(settings.url, {
       connect: {
-        strictSSL: 'insecureSkipTlsVerify' in settings ? !settings.insecureSkipTlsVerify : true
+        rejectUnauthorized: 'insecureSkipTlsVerify' in settings ? !settings.insecureSkipTlsVerify : true
       }
     });
     const requestOptions = {
@@ -44,7 +44,7 @@ async function getTokenFromBasicAuth (settings) {
 
     const client = new Client(parsedAuthURL.origin, {
       connect: {
-        strictSSL: 'insecureSkipTlsVerify' in settings ? !settings.insecureSkipTlsVerify : true
+        rejectUnauthorized: 'insecureSkipTlsVerify' in settings ? !settings.insecureSkipTlsVerify : true
       }
     });
 


### PR DESCRIPTION
When running the module with `strictSSL` set to `false` (because I set `insecureSkipTlsVerify` to true and `strictSSL` is the opposite of `insecureSkipTlsVerify`) I receive the following error for a self signed certificate:
```
/Volumes/Work/stat-tracker/node_modules/openshift-rest-client/lib/basic-auth-request.js:7
  const err = new Error(requestError.message);
              ^

Error: self-signed certificate in certificate chain
    at buildError (/Volumes/Work/stat-tracker/node_modules/openshift-rest-client/lib/basic-auth-request.js:7:15)
    at /Volumes/Work/stat-tracker/node_modules/openshift-rest-client/lib/basic-auth-request.js:33:21
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  statusCode: 'SELF_SIGNED_CERT_IN_CHAIN'
}
```
Upon further investigation I found this answer https://stackoverflow.com/a/76227420 which states you can use `rejectUnauthorized` to ignore invalid (self signed) certificates.

Looking online, specifically at: https://stackoverflow.com/questions/49320486/nodejs-ssl-options-strictssl-vs-rejectunauthorized, I see that `strictSSL` and `rejectUnauthorized` are supposed to be equivalent, so I am unsure if there is an issue with `undici`, but changing `strictSSL` to `rejectUnauthorized` seem to fix the issue for me.