### PR TITLE
fix: Use `rejectUnauthorzed` instead of `strictSSL`

### DIFF
--- a/lib/authorization-server-request.js
+++ b/lib/authorization-server-request.js
@@ -18,7 +18,7 @@ const getAuthUrlFromOCP = async (url, insecureSkipTlsVerify = true) => {
   return new Promise((resolve, reject) => {
     const client = new Client(url, {
       connect: {
-        strictSSL: insecureSkipTlsVerify
+        rejectUnauthorized: insecureSkipTlsVerify
       }
     });
     const requestOptions = {

--- a/lib/basic-auth-request.js
+++ b/lib/basic-auth-request.js
@@ -15,7 +15,7 @@ async function getUserFromAuthToken (settings) {
   return new Promise((resolve, reject) => {
     const client = new Client(settings.url, {
       connect: {
-        strictSSL: 'insecureSkipTlsVerify' in settings ? !settings.insecureSkipTlsVerify : true
+        rejectUnauthorized: 'insecureSkipTlsVerify' in settings ? !settings.insecureSkipTlsVerify : true
       }
     });
     const requestOptions = {
@@ -44,7 +44,7 @@ async function getTokenFromBasicAuth (settings) {
 
     const client = new Client(parsedAuthURL.origin, {
       connect: {
-        strictSSL: 'insecureSkipTlsVerify' in settings ? !settings.insecureSkipTlsVerify : true
+        rejectUnauthorized: 'insecureSkipTlsVerify' in settings ? !settings.insecureSkipTlsVerify : true
       }
     });
 

--- a/test/authorization-server-request-test.js
+++ b/test/authorization-server-request-test.js
@@ -52,7 +52,7 @@ test('authorization server request URL join safety', (t) => {
     static '@noCallThru' = true;
 
     constructor (url, options) {
-      t.equal(options.connect.strictSSL, false, 'strictSSL should be false');
+      t.equal(options.connect.rejectUnauthorized, false, 'rejectUnauthorized should be false');
       t.equal(url, `${BASE_URL}`, 'url should be equal to base url');
       this.url = url;
     }
@@ -94,7 +94,7 @@ test('authorization server request without insecureSkipTlsVerify', (t) => {
     static '@noCallThru' = true;
 
     constructor (url, options) {
-      t.equal(options.connect.strictSSL, true, 'strictSSL should be true');
+      t.equal(options.connect.rejectUnauthorized, true, 'rejectUnauthorized should be true');
     }
 
     request (options) {
@@ -133,7 +133,7 @@ test('authorization server request with empty body', (t) => {
     static '@noCallThru' = true;
 
     constructor (url, options) {
-      t.equal(options.connect.strictSSL, false, 'strictSSL should be false');
+      t.equal(options.connect.rejectUnauthorized, false, 'rejectUnauthorized should be false');
     }
 
     request (options) {
@@ -170,7 +170,7 @@ test('authorization server request with 404 status code', (t) => {
     static '@noCallThru' = true;
 
     constructor (url, options) {
-      t.equal(options.connect.strictSSL, false, 'strictSSL should be false');
+      t.equal(options.connect.rejectUnauthorized, false, 'rejectUnauthorized should be false');
     }
 
     request (options) {
@@ -198,7 +198,7 @@ test('authorization server request with error', (t) => {
     static '@noCallThru' = true;
 
     constructor (url, options) {
-      t.equal(options.connect.strictSSL, false, 'strictSSL should be false');
+      t.equal(options.connect.rejectUnauthorized, false, 'rejectUnauthorized should be false');
     }
 
     request (options) {

--- a/test/basic-auth-request-test.js
+++ b/test/basic-auth-request-test.js
@@ -9,7 +9,7 @@ test('basic auth request', (t) => {
     static '@noCallThru' = true;
 
     constructor (url, options) {
-      t.equal(options.connect.strictSSL, false, 'strictSSL should be false');
+      t.equal(options.connect.rejectUnauthorized, false, 'rejectUnauthorized should be false');
     }
 
     request (options) {
@@ -61,7 +61,7 @@ test('basic auth request with 404 status code', (t) => {
     static '@noCallThru' = true;
 
     constructor (url, options) {
-      t.equal(options.connect.strictSSL, false, 'strictSSL should be false');
+      t.equal(options.connect.rejectUnauthorized, false, 'rejectUnauthorized should be false');
     }
 
     request (options) {
@@ -119,7 +119,7 @@ test('basic auth request with 401 status code', (t) => {
     static '@noCallThru' = true;
 
     constructor (url, options) {
-      t.equal(options.connect.strictSSL, false, 'strictSSL should be false');
+      t.equal(options.connect.rejectUnauthorized, false, 'rejectUnauthorized should be false');
     }
 
     request (options) {
@@ -212,7 +212,7 @@ test('get user from token', (t) => {
     static '@noCallThru' = true;
 
     constructor (url, options) {
-      t.equal(options.connect.strictSSL, false, 'strictSSL should be false');
+      t.equal(options.connect.rejectUnauthorized, false, 'rejectUnauthorized should be false');
     }
 
     request (options) {
@@ -266,7 +266,7 @@ test('get user from token URL join safety', (t) => {
     static '@noCallThru' = true;
 
     constructor (url, options) {
-      t.equal(options.connect.strictSSL, false, 'strictSSL should be false');
+      t.equal(options.connect.rejectUnauthorized, false, 'rejectUnauthorized should be false');
       t.equal(url, `${BASE_URL}`, 'url should be equal to base url');
       this.url = url;
     }
@@ -317,7 +317,7 @@ test('get user from token with 401 status code', (t) => {
     static '@noCallThru' = true;
 
     constructor (url, options) {
-      t.equal(options.connect.strictSSL, false, 'strictSSL should be false');
+      t.equal(options.connect.rejectUnauthorized, false, 'rejectUnauthorized should be false');
     }
 
     request (options) {


### PR DESCRIPTION
Even though they should be the same thing, `strictSSL` was not working but `rejectUnauthorized` does.

frrom #390 but with added tests